### PR TITLE
Use bindgen generated opus bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,4 @@ repository = "https://github.com/SpaceManiac/opus-rs"
 documentation = "https://docs.rs/opus/0.2.1/opus/"
 
 [dependencies]
-opus-sys = "0.2.0"
-libc = "0.2"
+opusic-sys = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,13 +12,11 @@
 //! the [libopus documentation](https://opus-codec.org/docs/opus_api-1.1.2/).
 #![warn(missing_docs)]
 
-extern crate opus_sys as ffi;
-extern crate libc;
+extern crate opusic_sys as ffi;
 
 use std::ffi::CStr;
 use std::marker::PhantomData;
-
-use libc::c_int;
+use std::os::raw::c_int;
 
 // ============================================================================
 // Constants
@@ -552,7 +550,6 @@ pub mod packet {
 	use super::*;
 	use super::ffi;
 	use std::{ptr, slice};
-	use libc::c_int;
 
 	/// Get the bandwidth of an Opus packet.
 	pub fn get_bandwidth(packet: &[u8]) -> Result<Bandwidth> {


### PR DESCRIPTION
I re-wrote `opus-sys` using bindgen https://github.com/DoumanAsh/opusic-sys

On windows it uses pre-built static libraries while on unix-like systems and `windows-gnu` it expects to build using `make`

Closes #13