### PR TITLE
Add unsafe libopus backend: a pure-rust transpiled libopus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,12 @@ repository = "https://github.com/SpaceManiac/opus-rs"
 documentation = "https://docs.rs/opus/0.3.0/opus"
 
 [dependencies]
-audiopus_sys = "0.2.0"
-libc = "0.2"
+audiopus_sys = { version = "0.2.0", optional = true }
+libc = { version = "0.2", optional = true }
+unsafe-libopus = { version = "0.1.0", optional = true }
+cfg-if = "1.0.0"
+
+[features]
+default = ["audiopus-sys-backend"]
+audiopus-sys-backend = ["audiopus_sys", "libc"]
+unsafe-libopus-backend = ["unsafe-libopus"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "opus"
 version = "0.3.0"
 authors = ["Tad Hardesty <tad@platymuus.com>"]
+edition = "2021"
 
 description = "Safe Rust bindings for libopus"
 readme = "README.md"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,0 +1,46 @@
+use cfg_if::cfg_if;
+cfg_if!{
+    if #[cfg(all(feature = "audiopus-sys-backend", feature = "unsafe-libopus-backend"))] {
+        compile_error!("feature \"audiopus-sys-backend\" and feature \"unsafe-libopus-backend\" cannot be enabled at the same time");
+    } else if #[cfg(feature = "audiopus-sys-backend")] {
+        pub use audiopus_sys as ffi;
+        pub use libc::c_int as c_int;
+
+        macro_rules! ctl {
+            ($f:ident, $this:ident, $ctl:ident, $($rest:expr),*) => {
+                match unsafe { ffi::$f($this.ptr, $ctl, $($rest),*) } {
+                    code if code < 0 => return Err(Error::from_code(
+                        concat!(stringify!($f), "(", stringify!($ctl), ")"),
+                        code,
+                    )),
+                    _ => (),
+                }
+            }
+        }
+
+        pub(crate) use ctl;
+    } else if #[cfg(feature = "unsafe-libopus-backend")] {
+        #[allow(clippy::unsafe_removed_from_name)]
+        pub use unsafe_libopus as ffi;
+        #[allow(non_camel_case_types)]
+        pub type c_int = i32;
+
+        // defining C-style variadic functions in rust is unstable, so unsafe-libopus uses rust macros for its ctl functions
+        macro_rules! ctl {
+            ($f:ident, $this:ident, $ctl:ident, $($rest:expr),*) => {
+                match unsafe { ffi::$f!($this.ptr, $ctl, $($rest),*) } {
+                    code if code < 0 => return Err(Error::from_code(
+                        concat!(stringify!($f), "(", stringify!($ctl), ")"),
+                        code,
+                    )),
+                    _ => (),
+                }
+            }
+        }
+
+        pub(crate) use ctl;
+    } else {
+        compile_error!("either feature \"audiopus-sys-backend\" or feature \"unsafe-libopus-backend\" must be enabled");
+    }
+
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,7 @@
 //! the [libopus documentation](https://opus-codec.org/docs/opus_api-1.1.2/).
 #![warn(missing_docs)]
 
-extern crate audiopus_sys as ffi;
-extern crate libc;
+use audiopus_sys as ffi;
 
 use std::convert::TryFrom;
 use std::ffi::CStr;
@@ -138,7 +137,7 @@ pub enum ErrorCode {
 
 impl ErrorCode {
 	fn from_int(value: c_int) -> ErrorCode {
-		use ErrorCode::*;
+		use crate::ErrorCode::*;
 		match value {
 			ffi::OPUS_BAD_ARG => BadArg,
 			ffi::OPUS_BUFFER_TOO_SMALL => BufferTooSmall,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,13 +12,14 @@
 //! the [libopus documentation](https://opus-codec.org/docs/opus_api-1.1.2/).
 #![warn(missing_docs)]
 
-use audiopus_sys as ffi;
+mod backend;
 
 use std::convert::TryFrom;
 use std::ffi::CStr;
 use std::marker::PhantomData;
 
-use libc::c_int;
+
+use backend::{c_int, ffi, ctl};
 
 // ============================================================================
 // Constants
@@ -187,23 +188,12 @@ macro_rules! ffi {
 	}
 }
 
-macro_rules! ctl {
-	($f:ident, $this:ident, $ctl:ident, $($rest:expr),*) => {
-		match unsafe { ffi::$f($this.ptr, $ctl, $($rest),*) } {
-			code if code < 0 => return Err(Error::from_code(
-				concat!(stringify!($f), "(", stringify!($ctl), ")"),
-				code,
-			)),
-			_ => (),
-		}
-	}
-}
-
 // ============================================================================
 // Encoder
 
 macro_rules! enc_ctl {
 	($this:ident, $ctl:ident $(, $rest:expr)*) => {
+		// ctl! macro exported by the backend
 		ctl!(opus_encoder_ctl, $this, $ctl, $($rest),*)
 	}
 }
@@ -593,7 +583,7 @@ unsafe impl Send for Decoder {}
 pub mod packet {
 	use super::ffi;
 	use super::*;
-	use libc::c_int;
+	use backend::c_int;
 	use std::{ptr, slice};
 
 	/// Get the bandwidth of an Opus packet.


### PR DESCRIPTION
The `unsafe-libopus` library does not have a dependency on C toolchain, allowing for easier deployment to some targets

This PR adds `audiopus-sys-backend` and `unsafe-libopus-backend` features with `audiopus-sys-backend` being enabled by default.