### PR TITLE
Remove dependency on libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,3 @@ documentation = "https://docs.rs/opus/0.3.0/opus"
 
 [dependencies]
 audiopus_sys = "0.2.0"
-libc = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,13 +13,11 @@
 #![warn(missing_docs)]
 
 extern crate audiopus_sys as ffi;
-extern crate libc;
 
 use std::convert::TryFrom;
 use std::ffi::CStr;
+use std::os::raw::c_int;
 use std::marker::PhantomData;
-
-use libc::c_int;
 
 // ============================================================================
 // Constants
@@ -609,7 +607,6 @@ unsafe impl Send for Decoder {}
 pub mod packet {
 	use super::ffi;
 	use super::*;
-	use libc::c_int;
 	use std::{ptr, slice};
 
 	/// Get the bandwidth of an Opus packet.


### PR DESCRIPTION
Isn't it rather overkill to have a dependency just for `c_int`?

There's also [`std::ffi::c_int`](https://doc.rust-lang.org/std/ffi/type.c_int.html) but that would bump MSRV to 1.64.0.