### PR TITLE
Replace audiopus_sys with maintained opusic-sys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ repository = "https://github.com/SpaceManiac/opus-rs"
 documentation = "https://docs.rs/opus/0.3.0/opus"
 
 [dependencies]
-audiopus_sys = "0.2.0"
+opusic-sys = "0.5.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! the [libopus documentation](https://opus-codec.org/docs/opus_api-1.1.2/).
 #![warn(missing_docs)]
 
-extern crate audiopus_sys as ffi;
+extern crate opusic_sys as ffi;
 
 use std::convert::TryFrom;
 use std::ffi::CStr;


### PR DESCRIPTION
https://github.com/Lakelezz/audiopus_sys has not been updated in three years, the bundled opus is quite old, so this pr switches to using https://github.com/DoumanAsh/opusic-sys.

The upside is the included opus is 1.5.2, the downside is I dislike that the opus source is in the repo without history. I'd prefer a submodule or subtree, but it seems like it's the best bindings currently.